### PR TITLE
Instructions for bundling with Babelify

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,40 @@ plugins: [
 
 Adding the `custom.optimize` property in `s-component.json` applies the optimization setting to ALL functions in that component.  Adding the `custom.optimize` property to `s-function.json` applies the optimization setting to ONLY that specific function.  You can use `custom.optimize` in both places.  The `custom.optimize` setting in `s-function.json` will override the setting in `s-component.json`.
 
-We're currently working on adding support for Babelify and Typsecript.  Check back for updates!
+
+## ES6 with Babel and Babelify
+
+Bundles can be transformed to support ES6 features.
+
+Assuming you have a node component called "nodejscomponent", install babelify within the context of that component:
+
+```shell
+cd nodejscomponent && npm install babelify babel-preset-es2015 --save
+```
+
+Add the babelify transform to `s-component.json`:
+
+```javascript
+{
+    "name": "nodejscomponent",
+    "runtime": "nodejs",
+    "custom": {
+        "optimize": {
+            "transforms": [
+                {
+                    "name": "babelify",
+                    "opts": {
+                        "presets": [
+                            "es2015"
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
+```
+
+
+We're currently working on adding support for Typsecript.  Check back for updates!

--- a/README.md
+++ b/README.md
@@ -37,13 +37,19 @@ Adding the `custom.optimize` property in `s-component.json` applies the optimiza
 
 ## ES6 with Babel and Babelify
 
-Bundles can be transformed to support ES6 features.
+Bundles are packaged with Browserify, and can be transformed to support ES6 features with Babelify.
 
-Assuming you have a node component called "nodejscomponent", install babelify within the context of that component:
 
-```shell
-cd nodejscomponent && npm install babelify babel-preset-es2015 --save
-```
+Install babelify within the root context of your project:
+
+    npm install babelify --save
+
+
+Assuming you have a node component called "nodejscomponent", install any babelify presets within the context of that component:
+
+
+    cd nodejscomponent && npm install babel-preset-es2015 --save
+
 
 Add the babelify transform to `s-component.json`:
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ module.exports = function(ServerlessPlugin) {
     _           = require('lodash'),
     fs          = require('fs'),
     os          = require('os'),
-    babelify    = require('babelify'),
     browserify  = require('browserify'),
     UglifyJS    = require('uglify-js'),
     wrench      = require('wrench'),
@@ -134,7 +133,7 @@ module.exports = function(ServerlessPlugin) {
 
     /**
      * Browserify
-     * - Options: babelify, transform, exclude, minify, ignore
+     * - Options: transform, exclude, minify, ignore
      */
 
     browserify() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-optimizer-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "engines": {
     "node": ">=4.0"
   },
@@ -33,13 +33,12 @@
     "test": "mocha tests/all"
   },
   "devDependencies": {
-    "chai": "^3.2.0",
-    "mocha": "^2.2.5"
+    "chai": "^3.4.1",
+    "mocha": "^2.3.4"
   },
   "dependencies": {
-    "babelify": "^7.2.0",
-    "bluebird": "^3.0.6",
-    "browserify": "^12.0.1",
+    "bluebird": "^3.1.1",
+    "browserify": "^13.0.0",
     "lodash": "^4.0.0",
     "uglify-js": "^2.6.1",
     "wrench": "^1.5.8"


### PR DESCRIPTION
*\* I removed the direct Babelify dependency **. I think it's best if this plugin remains agnostic about any Browserify transforms you might add. 

However, as you can see in the README, this makes installing those deps a little awkward.

I also bumped the minor version number, along with the latest Browserify version and such. 
