### PR TITLE
Read includePaths from config object

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,10 +257,10 @@ module.exports = function(ServerlessPlugin) {
         fullPath;
 
       // Skip if undefined
-      if (!_this.function.custom.includePaths) return compressPaths;
+      if (!_this.config.includePaths) return compressPaths;
 
       // Collect includePaths
-      _this.function.custom.includePaths.forEach(p => {
+      _this.config.includePaths.forEach(p => {
 
         try {
           fullPath = path.resolve(path.join(_this.evt.data.pathDist, p));

--- a/index.js
+++ b/index.js
@@ -203,7 +203,7 @@ module.exports = function(ServerlessPlugin) {
 
             // Minify browserified data
 
-            if (_this.function.custom.optimize && _this.function.custom.optimize.minify !== false) {
+            if (_this.config.minify !== false) {
 
               let result = UglifyJS.minify(_this.pathBundled, uglyOptions);
 


### PR DESCRIPTION
From my understanding, I should be able to configure the optimize plugin like this, i.e. defining the `includePaths` property as part of the `optimize` block:

```
  "custom": {
    "optimize": {
      "includePaths": [
        "config"
      ]
    },
  }
```

However, that doesn't work as expected. Currently the plugin loads the `includePaths` directly from the `custom` object and only (!) the one defined in `s-function.json`, but not from `s-component.json`.

I figured this is a bug and provided a very simple fix.
