### PR TITLE
Updated an instruction to exclude aws-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Add the babelify transform to `s-component.json`:
     "runtime": "nodejs",
     "custom": {
         "optimize": {
+            "exclude": [ "aws-sdk" ],
             "transforms": [
                 {
                     "name": "babelify",


### PR DESCRIPTION
I have added "exclude": [ "aws-sdk" ] to s-component.json to avoid errors. 
https://gyazo.com/2fb6ddea44a34f8385c18e17272f3948
After digging into minified code, I found out that it was related to aws-sdk.
