### PR TITLE
Fix for runtime option check

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ module.exports = function(ServerlessPlugin) {
       }
 
       // Optimize: Nodejs
-      if (func.runtime === 'nodejs') {
+      if (component.runtime === 'nodejs') {
         optimizer = new OptimizeNodejs(this.S, evt, component, func);
         return optimizer.optimize()
           .then(function(evt) {


### PR DESCRIPTION
Since `runtime` option has been removed from `s-function.json` in Serverless 0.1.3, we have to replace `func.runtime` with `component.runtime` in the plugin otherwise it won't work if `runtime` option is not specified inside `s-function.json`.
