### PR TITLE
Add support for browserify opts.extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,8 @@ module.exports = function(ServerlessPlugin) {
         plugins:      [],
         transforms:   [],
         exclude:      [],
-        ignore:       []
+        ignore:       [],
+        extensions:   []
       };
       _this.config = _.merge(
         _this.config,
@@ -148,6 +149,7 @@ module.exports = function(ServerlessPlugin) {
         basedir:          fs.realpathSync(_this.evt.data.pathDist),
         entries:          [_this.function.handler.split('.')[0] + '.' + _this.config.handlerExt],
         standalone:       'lambda',
+        extensions:       _this.config.extensions,
         browserField:     false,  // Setup for node app (copy logic of --node in bin/args.js)
         builtins:         false,
         commondir:        false,


### PR DESCRIPTION
From the browserify docs:
“opts.extensions is an array of optional extra extensions for the
module lookup machinery to use when the extension has not been
specified. By default browserify considers only .js and .json files in
such cases.”

Example usage:

```
"custom": {
    "optimize": {
        "handlerExt": "coffee",
        "extensions": [".coffee"],
      "exclude": [
        "aws-sdk"
      ],
      "transforms": [
        {
          "name": "coffeeify"
        }
      ]
    }
  }
```

With this pull request, serverless-optimizer-plugin would provide full coffeescript support. I saw that you have Typescript support on the roadmap, this would also support requires without the '.ts' extension. A small convenience, but nice to have.
