### PR TITLE
Fix Setup Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,16 @@ npm install serverless-optimizer-plugin --save
 
 ```
 "custom": {
-	"optimize": true
+        "optimize": {
+            "exclude": [ "aws-sdk" ]
+      	}
 }
 ```
 
 * Add the plugin to the `plugins` array in your Serverless Project's `s-project.json`, like this:
 
 ```
-plugins: [
+"plugins": [
     "serverless-optimizer-plugin"
 ]
 ```


### PR DESCRIPTION
Fix Setup Instructions
1. plugins requires quotes
2. optimize requires exclusion of aws-sdk to function correctly upon deployment (if aws-sdk is used)
