### PR TITLE
Include paths src and dst support

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,9 @@ module.exports = function(S) {
 
       // Get function
       let func = S.getProject().getFunction(evt.options.name),
+          populated = func.toObjectPopulated(evt.options),
           optimizer;
+      func.custom = populated.custom;
 
       // Skip if no optimization is set on function
       if (!func.custom || !func.custom.optimize) {

--- a/index.js
+++ b/index.js
@@ -283,9 +283,16 @@ module.exports = function(S) {
               deferredCopies = [];
 
           includePaths.forEach(p => {
-            let destPath = path.join(_this.optimizedDistPath, p),
-                srcPath  = path.join(_this.evt.options.pathDist, p),
-                destDir  = (fs.lstatSync(p).isDirectory()) ? destPath : path.dirname(destPath);
+            let destPath, srcPath, destDir;
+            if( p.src && p.dest ){
+              destPath = path.join(_this.optimizedDistPath, p.dest);
+              srcPath  = path.join(_this.evt.options.pathDist, p.src);
+              destDir  = destPath;
+            } else {
+              destPath = path.join(_this.optimizedDistPath, p);
+              srcPath  = path.join(_this.evt.options.pathDist, p);
+              destDir  = (fs.lstatSync( srcPath ).isDirectory()) ? destPath : path.dirname(destPath);
+            }
 
             fs.mkdirsSync(destDir, '0777');
             deferredCopies.push(


### PR DESCRIPTION
This way some node_modules may be included directly into zip, without undergoing optimization (some modules, e.g. Postgres drivers, don't go well with optimization) .

This is an equivalent of #3 and #21, updated for current version of this plugin.
