### PR TITLE
catch lstat ENOENT to set destDir when using includesPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,7 +256,7 @@ module.exports = function(S) {
               S.utils.sDebug(`Minifying bundled file ${optimizedFile}`);
 
               let result;
-              
+
               try {
                 result = UglifyJS.minify(optimizedFile, uglyOptions);
               } catch (e) {
@@ -285,8 +285,13 @@ module.exports = function(S) {
           includePaths.forEach(p => {
             let destPath = path.join(_this.optimizedDistPath, p),
                 srcPath  = path.join(_this.evt.options.pathDist, p),
-                destDir  = (fs.lstatSync(p).isDirectory()) ? destPath : path.dirname(destPath);
+                destDir  = undefined;
 
+            try {
+              destDir = (fs.lstatSync(p).isDirectory()) ? destPath : path.dirname(destPath);
+            } catch (e) {
+              destDir = path.dirname(destPath);
+            }
             fs.mkdirsSync(destDir, '0777');
             deferredCopies.push(
               fs.copyAsync(srcPath, destPath, {clobber: true, dereference: true})


### PR DESCRIPTION
I'm not convinced that this is the most elegant approach and am open to further discussion. As it stands the ternary operator will exit when `fs.lstatSync()` throws the ENOENT error. In that case I set the `destDir` to the optimized path plus the included path. I tried `fs.lstat()` but I ran into async issues there. I also entertained the idea of using `fs.exists()` as it would have been a small addition to the already existing ternary operator. However, it's deprecated causing me to look for a new solution.
