### PR TITLE
Fix bundling entrypoint naming issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,7 +183,7 @@ module.exports = function(S) {
             compress: {}
           };
 
-      const handlerName   = this.function.getHandler(),
+      const handlerName   = this.function.handler,
             bundleBaseDir = fs.realpathSync(_this.evt.options.pathDist),
             bundleEntryPt = handlerName.split('.')[0] + '.' + _this.config.handlerExt;
 
@@ -256,7 +256,7 @@ module.exports = function(S) {
               S.utils.sDebug(`Minifying bundled file ${optimizedFile}`);
 
               let result;
-              
+
               try {
                 result = UglifyJS.minify(optimizedFile, uglyOptions);
               } catch (e) {


### PR DESCRIPTION
`this.function.getHandler()` always returns `{directory to handler}/_serverless_handler.handler`, which is the name of the _bundled_ handler, but is not the name of the _source handler file_. This means that the entry point to browserify is actually incorrect, causing e.g. CoffeeScript transpilation to fail.
